### PR TITLE
Update docker-compose-sample.yml

### DIFF
--- a/docker-compose-sample.yml
+++ b/docker-compose-sample.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
     mirakurun:
         image: chinachu/mirakurun


### PR DESCRIPTION
https://docs.docker.com/compose/compose-file/
に書いてある通り、最新のdocker-composeでは、composeファイル内におけるversionの指定が必要なくなっています。