### PR TITLE
fix if there isn't subtitles

### DIFF
--- a/epgstation/config/enc.js.template
+++ b/epgstation/config/enc.js.template
@@ -53,7 +53,7 @@ if (isDualMono) {
     Array.prototype.push.apply(args, ['-map', '0:a', '-c:a', 'copy']);
 }
 // 字幕ストリーム設定
-Array.prototype.push.apply(args, ['-map', '0:s', '-c:s', 'mov_text']);
+Array.prototype.push.apply(args, ['-map', '0:s?', '-c:s', 'mov_text']);
 // 品質設定
 Array.prototype.push.apply(args, ['-preset', 'fast']);
 // 出力ファイル


### PR DESCRIPTION
字幕がなくても字幕ストリームは含める仕様だと思っていたのですが，一部ローカルのケーブルテレビで字幕ストリームが格納されていない場合がありました
その字幕の変換をスキップするようにしました