### PR TITLE
Update ffmpeg version

### DIFF
--- a/epgstation/alpine.Dockerfile
+++ b/epgstation/alpine.Dockerfile
@@ -1,7 +1,7 @@
 FROM l3tnun/epgstation:alpine
 
 ENV DEV="autoconf automake bash binutils bzip2 cmake curl coreutils diffutils file g++ gcc gperf libtool make python3 openssl-dev tar yasm nasm zlib-dev expat-dev pkgconfig libass-dev lame-dev opus-dev libtheora-dev libvorbis-dev libvpx-dev x264-dev x265-dev libva-dev"
-ENV FFMPEG_VERSION=4.2.4
+ENV FFMPEG_VERSION=6.1.1
 # intel環境でハードウェアエンコードを利用したい場合は下記をコメントアウト
 # ENV LD_LIBRARY_PATH=/opt/intel/mediasdk/lib64
 # ENV PKG_CONFIG_PATH=/opt/intel/mediasdk/lib64/pkgconfig

--- a/epgstation/config/enc.js.template
+++ b/epgstation/config/enc.js.template
@@ -49,6 +49,7 @@ if (isDualMono) {
         '-map', '[FR]',
         '-metadata:s:a:0', 'language=jpn',
         '-metadata:s:a:1', 'language=eng',
+        '-ac', '1',
     ]);
 } else {
     Array.prototype.push.apply(args, ['-map', '0:a']);

--- a/epgstation/debian.Dockerfile
+++ b/epgstation/debian.Dockerfile
@@ -1,7 +1,7 @@
 FROM l3tnun/epgstation:master-debian
 
 ENV DEV="make gcc git g++ automake curl wget autoconf build-essential libass-dev libfreetype6-dev libsdl1.2-dev libtheora-dev libtool libva-dev libvdpau-dev libvorbis-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev pkg-config texinfo zlib1g-dev"
-ENV FFMPEG_VERSION=4.2.4
+ENV FFMPEG_VERSION=6.1.1
 
 RUN apt-get update && \
     apt-get -y install $DEV && \


### PR DESCRIPTION
# 概要

ffmpegのバージョンを最新の安定版リリースにアップグレードします。

## 補足

`enc.js.template`について

2カ国語放送の音声を分割してそれぞれの音声に分割する場合、ffmpegのバージョンをアップグレードしたことによって、`-ac 1`のオプションを追加しなければエラーが発生するので修正しています。



