### PR TITLE
fix epgstation/alpine.Dockerfile

### DIFF
--- a/epgstation/alpine.Dockerfile
+++ b/epgstation/alpine.Dockerfile
@@ -6,7 +6,7 @@ ENV FFMPEG_VERSION=7.0
 # ENV LD_LIBRARY_PATH=/opt/intel/mediasdk/lib64
 # ENV PKG_CONFIG_PATH=/opt/intel/mediasdk/lib64/pkgconfig
 
-RUN apk add --no-cache libgcc libstdc++ ca-certificates libcrypto1.1 libssl1.1 libgomp expat git lame libass libvpx opus libtheora libvorbis x264-libs x265-libs libva $DEV && \
+RUN apk add --no-cache libgcc libstdc++ ca-certificates libgomp expat git lame-libs libass libvpx opus libtheora libvorbis x264-libs x265-libs libva $DEV && \
 # aribb24
     mkdir /tmp/aribb24 && cd /tmp/aribb24 && \
     curl -fsSL https://github.com/nkoriyama/aribb24/tarball/master | tar -xz --strip-components=1 && \


### PR DESCRIPTION
## 概要(Summary)

Alpine向けのコンテナビルドがエラーとなっていたので、パッケージのインストール部分で以下の変更をしました。
- ffmpegのビルド&依存ライブラリで使っていなく、Alpineパッケージのmainリポジトリからも無くなっている、OpenSSL1系のライブラリを除外
- libmp3lame.so.0 のライブラリを含むパッケージ名を変更

手元で確認した限り、コンテナビルドが通り、ffmpegも動作できるようになっています。
ご確認よろしくお願いします。
