### PR TITLE
Bump MariaDB to 10.6

### DIFF
--- a/docker-compose-sample.yml
+++ b/docker-compose-sample.yml
@@ -24,7 +24,7 @@ services:
                 max-size: 10m
 
     mysql:
-        image: mariadb:10.5
+        image: mariadb:10.6
         # image: mysql:8.0 # 囲み文字を使用する場合
         volumes:
             - mysql-db:/var/lib/mysql


### PR DESCRIPTION
## Why

docker-compose-sample.yml で例示されている MariaDB 10.5 は 2025 年 6 月 24 日を以て無償版のメンテナンス期限を迎えます。cf. https://mariadb.com/kb/en/mariadb-server-release-dates/
MariaDB 10.5 から MariaDB 10.6 の間に破壊的変更は殆ど無い（cf. https://mariadb.com/kb/en/upgrading-from-mariadb-10-5-to-mariadb-10-6/ ）ようですし、実際に動かした限りでは問題も起きていないので、無償版でも 2026 年 7 月までメンテナンスされる MariaDB 10.6 に移行してはどうでしょうか？

## What

docker-compose-sample.yml で用いる MariaDB のバージョンを 10.6 に上げます。
これにより、メンテナンス期限までの猶予が一年ほど伸びる見込みです。